### PR TITLE
Force Spanish locale for Consentmanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 playwright-report
 test-results
+.playwright-cli
 *.local
 
 # Editor directories and files

--- a/docs/third-party-integrations.md
+++ b/docs/third-party-integrations.md
@@ -14,6 +14,11 @@ these services fail to load.
   remain inactive until the user allows them
 - Privacy note: this is the primary consent layer and should remain ahead of
   analytics/bootstrap scripts
+- Language note: the site is Spanish-first, so the integration pins the CMP
+  language to `ES` in [`index.html`](../index.html) before the autoblocking
+  script loads
+- Operational note: copy for the first-layer dialog and blocked YouTube preview
+  cards is managed in the consentmanager dashboard, not in React components
 
 ## Google Tag Manager
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
   <meta name="twitter:image" content="https://balrockoficial.com/images/balrock.jpeg" />
 </head>
 <!--Consent Manager-->
+<script>
+  window.cmp_setlang = 'ES';
+</script>
 <script type="text/javascript" data-cmp-ab="1" src="https://cdn.consentmanager.net/delivery/autoblocking/44bf7d4272b15.js" data-cmp-host="d.delivery.consentmanager.net" data-cmp-cdn="cdn.consentmanager.net" data-cmp-codesrc="0"></script>
 <!--Consent Manager-->
 <!-- Google Tag Manager -->

--- a/src/consentManager.test.js
+++ b/src/consentManager.test.js
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const indexHtml = readFileSync(resolve(process.cwd(), "index.html"), "utf8");
+
+describe("Consentmanager integration", () => {
+  it("forces the consent layer language to Spanish before the CMP script loads", () => {
+    expect(indexHtml).toMatch(
+      /window\.cmp_setlang\s*=\s*['"]ES['"];[\s\S]*cdn\.consentmanager\.net\/delivery\/autoblocking\/44bf7d4272b15\.js/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- force Consentmanager to initialize with the Spanish locale before the autoblocking script loads
- document that consent and blocked-embed copy is owned in the consentmanager dashboard
- add a regression test for the Spanish-first CMP integration

## Testing
- npm run lint
- npm run test

## Follow-up
- Consentmanager dashboard copy and first-layer design still need to be updated in production to fully close issue #14.